### PR TITLE
Update to bevy 0.11.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_wasm_window_resize"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 repository = "https://github.com/Leinnan/bevy_wasm_window_resize"
 homepage = "https://github.com/Leinnan/bevy_wasm_window_resize"
@@ -11,7 +11,7 @@ categories  = ["game-engines"]
 description = "Bevy helper crate that makes application canvas match window size."
 
 [dependencies]
-bevy = "0.10.0"
+bevy = "0.11.0"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 web-sys = "0.3.61"

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ use bevy_wasm_window_resize::WindowResizePlugin;
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugin(WindowResizePlugin)
+        .add_plugins(WindowResizePlugin)
         .run();
 }
 ```
@@ -31,3 +31,4 @@ fn main() {
 Bevy version | crate version
 --- | ---
 0.10 | 0.1.0
+0.11 | 0.2.0

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,9 @@ pub struct WindowResizePlugin;
 impl Plugin for WindowResizePlugin {
     #[cfg(target_arch = "wasm32")]
     fn build(&self, app: &mut App) {
-        app.add_system(handle_browser_resize);
+        use bevy::prelude::Update;
+
+        app.add_systems(Update, handle_browser_resize);
     }
 
     #[cfg(not(target_arch = "wasm32"))]


### PR DESCRIPTION
# Motivation

Update to bevy to version 0.11.0

## Changes

- update bevy dependency version to 0.11.0
- replace [deprecated `add_plugin`](https://bevyengine.org/learn/migration-guides/0.10-0.11/#allow-tuples-and-single-plugins-in-add-plugins-deprecate-add-plugin) with `add_plugins`
- replace [deprecated `add_system`](https://bevyengine.org/learn/migration-guides/0.10-0.11/#schedule-first-the-new-and-improved-add-systems) with `add_systems` in readme
- bump crate version to 2.0.0
- update readme's compatibility table